### PR TITLE
Get rules by tags

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -194,6 +194,7 @@ class Fastly {
    * @param tag {string} The WAF tag whose rules are enabled on a service.
    * @return {Promise} The response object representing the completion or failure.
    * @param pageNumber {number} Page number for the of the results output.
+   * @return {Promise} An array of response object(s) representing the completion or failure.
    */
   getWafRulesByTags(wafId = '', tag = '', pageNumber = '') {
       return this.request.get(`/service/${this.service_id}/wafs/${wafId}/rule_statuses?filter[rule][tags][name]=${tag}&page[size]=200&page[number]=${pageNumber}`)

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ class Fastly {
     this.request = axios.create({
       baseURL: config.mainEntryPoint,
       timeout: 3000,
-      headers: { 'Fastly-Key': token }
+      headers: {'Fastly-Key': token}
     });
   }
 
@@ -50,7 +50,7 @@ class Fastly {
    * @return {Promise} The response object representing the completion or failure.
    */
   purgeKeys(keys = []) {
-    return this.request.post(`/service/${this.service_id}/purge`, { 'surrogate_keys': keys });
+    return this.request.post(`/service/${this.service_id}/purge`, {'surrogate_keys': keys});
   }
 
   /**
@@ -68,7 +68,7 @@ class Fastly {
    * @return {Promise} The response object representing the completion or failure.
    */
   softPurgeKey(key = '') {
-    return this.request.post(`/service/${this.service_id}/purge/${key}`, undefined, { headers: { 'Fastly-Soft-Purge': 1 } });
+    return this.request.post(`/service/${this.service_id}/purge/${key}`, undefined, {headers: {'Fastly-Soft-Purge': 1}});
   }
 
   /**
@@ -188,7 +188,29 @@ class Fastly {
     return this.request.get(`/service/${this.service_id}/wafs/${wafId}/rule_statuses?filter[status]=${wafStatus}&page[size]=200&page[number]=${pageNumber}`)
   }
 
-
+  /**
+   * Gets the WAF Rules associated with a service dependant on WAF tags.
+   * @param wafId {string} The WAF ID associated with a service.
+   * @param tags {string} The WAF tag whose rules are enabled on a service.
+   * @return {Promise} The response object representing the completion or failure.
+   */
+  // getWafRulesByTags(wafId = '', tags = config.WAFTags, pageNumber = '') {
+  //   const WafTags= tags.map((tag) =>{
+  //     return this.request.get(`/service/${this.service_id}/wafs/${wafId}/rule_statuses?filter[rule][tags][name]=${tag}&page[size]=200&page[number]=${pageNumber}`)
+  //   });
+  //   return axios.all(WafTags); //returns an array of responses(Type : object)
+  // }
+  getWafRulesByTags(wafId = "", tags = "") {
+    const localRequest=this.request;
+    const service_id=this.service_id;
+    //this.request.get(`/service/${this.service_id}/wafs/${wafId}/rule_statuses?filter[rule][tags][name]=${tag}&page[size]=200&page[number]=${pageNumber}`)
+    this.request.get(`/service/${this.service_id}/wafs/${wafId}/rule_statuses?filter[rule][tags][name]=${tag}`);
+    if
+    return (function getAllPages(page = 1) {
+      return localRequest.get(`/service/${service_id}/wafs/${wafId}/rule_statuses?filter[rule][tags][name]=${tags}&page[number]=${page}&page[size]=200`)
+        .then(response => response.data.length == 200 ? getAllPages(page + 1).then(data => response.data.concat(data)) : response)
+    })();
+  }
   /**
    * Updates the status of all the rules by a tag.By default, updates all the tags. Doesnt need a PATCH
    * @param wafId {string} The WAF ID associated with a service.
@@ -209,7 +231,7 @@ class Fastly {
       };
       //Override timeout for this request as it's known to take a long time- updates every rule in the tag one by one
       return this.request.post(`/service/${this.service_id}/wafs/${wafId}/rule_statuses`, data, {
-        timeout:30000,
+        timeout: 30000,
         headers: {
           'Accept': 'application/vnd.api+json',
           'Content-Type': 'application/vnd.api+json'

--- a/src/index.js
+++ b/src/index.js
@@ -191,25 +191,12 @@ class Fastly {
   /**
    * Gets the WAF Rules associated with a service dependant on WAF tags.
    * @param wafId {string} The WAF ID associated with a service.
-   * @param tags {string} The WAF tag whose rules are enabled on a service.
+   * @param tag {string} The WAF tag whose rules are enabled on a service.
    * @return {Promise} The response object representing the completion or failure.
+   * @param pageNumber {number} Page number for the of the results output.
    */
-  // getWafRulesByTags(wafId = '', tags = config.WAFTags, pageNumber = '') {
-  //   const WafTags= tags.map((tag) =>{
-  //     return this.request.get(`/service/${this.service_id}/wafs/${wafId}/rule_statuses?filter[rule][tags][name]=${tag}&page[size]=200&page[number]=${pageNumber}`)
-  //   });
-  //   return axios.all(WafTags); //returns an array of responses(Type : object)
-  // }
-  getWafRulesByTags(wafId = "", tags = "") {
-    const localRequest=this.request;
-    const service_id=this.service_id;
-    //this.request.get(`/service/${this.service_id}/wafs/${wafId}/rule_statuses?filter[rule][tags][name]=${tag}&page[size]=200&page[number]=${pageNumber}`)
-    this.request.get(`/service/${this.service_id}/wafs/${wafId}/rule_statuses?filter[rule][tags][name]=${tag}`);
-    if
-    return (function getAllPages(page = 1) {
-      return localRequest.get(`/service/${service_id}/wafs/${wafId}/rule_statuses?filter[rule][tags][name]=${tags}&page[number]=${page}&page[size]=200`)
-        .then(response => response.data.length == 200 ? getAllPages(page + 1).then(data => response.data.concat(data)) : response)
-    })();
+  getWafRulesByTags(wafId = '', tag = '', pageNumber = '') {
+      return this.request.get(`/service/${this.service_id}/wafs/${wafId}/rule_statuses?filter[rule][tags][name]=${tag}&page[size]=200&page[number]=${pageNumber}`)
   }
   /**
    * Updates the status of all the rules by a tag.By default, updates all the tags. Doesnt need a PATCH

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ class Fastly {
     this.request = axios.create({
       baseURL: config.mainEntryPoint,
       timeout: 3000,
-      headers: {'Fastly-Key': token}
+      headers: { 'Fastly-Key': token }
     });
   }
 
@@ -50,7 +50,7 @@ class Fastly {
    * @return {Promise} The response object representing the completion or failure.
    */
   purgeKeys(keys = []) {
-    return this.request.post(`/service/${this.service_id}/purge`, {'surrogate_keys': keys});
+    return this.request.post(`/service/${this.service_id}/purge`, { 'surrogate_keys': keys });
   }
 
   /**
@@ -68,7 +68,7 @@ class Fastly {
    * @return {Promise} The response object representing the completion or failure.
    */
   softPurgeKey(key = '') {
-    return this.request.post(`/service/${this.service_id}/purge/${key}`, undefined, {headers: {'Fastly-Soft-Purge': 1}});
+    return this.request.post(`/service/${this.service_id}/purge/${key}`, undefined, { headers: { 'Fastly-Soft-Purge': 1 } });
   }
 
   /**
@@ -188,7 +188,29 @@ class Fastly {
     return this.request.get(`/service/${this.service_id}/wafs/${wafId}/rule_statuses?filter[status]=${wafStatus}&page[size]=200&page[number]=${pageNumber}`)
   }
 
-
+  /**
+   * Gets the WAF Rules associated with a service dependant on WAF tags.
+   * @param wafId {string} The WAF ID associated with a service.
+   * @param tags {string} The WAF tag whose rules are enabled on a service.
+   * @return {Promise} The response object representing the completion or failure.
+   */
+  // getWafRulesByTags(wafId = '', tags = config.WAFTags, pageNumber = '') {
+  //   const WafTags= tags.map((tag) =>{
+  //     return this.request.get(`/service/${this.service_id}/wafs/${wafId}/rule_statuses?filter[rule][tags][name]=${tag}&page[size]=200&page[number]=${pageNumber}`)
+  //   });
+  //   return axios.all(WafTags); //returns an array of responses(Type : object)
+  // }
+  getWafRulesByTags(wafId = "", tags = "") {
+    const localRequest=this.request;
+    const service_id=this.service_id;
+    //this.request.get(`/service/${this.service_id}/wafs/${wafId}/rule_statuses?filter[rule][tags][name]=${tag}&page[size]=200&page[number]=${pageNumber}`)
+    this.request.get(`/service/${this.service_id}/wafs/${wafId}/rule_statuses?filter[rule][tags][name]=${tag}`);
+    if
+    return (function getAllPages(page = 1) {
+      return localRequest.get(`/service/${service_id}/wafs/${wafId}/rule_statuses?filter[rule][tags][name]=${tags}&page[number]=${page}&page[size]=200`)
+        .then(response => response.data.length == 200 ? getAllPages(page + 1).then(data => response.data.concat(data)) : response)
+    })();
+  }
   /**
    * Updates the status of all the rules by a tag.By default, updates all the tags. Doesnt need a PATCH
    * @param wafId {string} The WAF ID associated with a service.

--- a/test/getWafRules.test.js
+++ b/test/getWafRules.test.js
@@ -11,7 +11,6 @@ describe('#getWafRules', () => {
   let res;
 
   nock(config.mainEntryPoint)
-   .log(console.log)
    .get('/service/79CEhEeP8DKPQQGiXokV5M/wafs/rfjm9II8V21LSeEgyMi9x/rule_statuses?filter[status]=log&page[size]=200&page[number]=1')
    .reply(200, response.getWafRules);
 

--- a/test/getWafRulesByTags.test.js
+++ b/test/getWafRulesByTags.test.js
@@ -11,12 +11,12 @@ describe('#getWafRulesByTags', () => {
   let res;
 
   nock(config.mainEntryPoint)
-    .log(console.log)
-    .get('/service/79CEhEeP8DKPQQGTXokV5M/wafs/rfjn9II8V21LSeEgyMT9x/rule_statuses?filter[rule][tags][name]=language-css&page[number]=1&page[size]=200')
+    //.log(console.log)
+    .get('/service/79CEhEeP8DKPQQGTXokV5M/wafs/rfjn9II8V21LSeEgyMT9x/rule_statuses?filter[rule][tags][name]=language-css&page[size]=200&page[number]=1')
     .reply(200, response.getWafRulesByTags);
 
   before(async () => {
-    res = await fastly.getWafRulesByTags('rfjn9II8V21LSeEgyMT9x','language-css');
+    res = await fastly.getWafRulesByTags('rfjn9II8V21LSeEgyMT9x','language-css','1');
   });
 
   it('response should be a status 200', () => {
@@ -31,12 +31,16 @@ describe('#getWafRulesByTags', () => {
     expect(Array.isArray(res.data.data)).toBe(true);
   });
 
+  it('response body should contain properties', () => {
+    expect(res.data).toIncludeKeys(['data', 'links', 'meta']);
+  });
+
   it('response should contain WAF ID rfjn9II8V21LSeEgyMT9x-2077876', () => {
     expect(res.data.data[0].id).toBe("rfjn9II8V21LSeEgyMT9x-2077876");
   });
 
-  it('response body should contain properties', () => {
-    expect(res.data).toIncludeKeys(['links', 'meta']);
+  it('response should only be 1 page long', () => {
+    expect(res.data.meta.total_pages).toBe(1);
   });
 
 });

--- a/test/getWafRulesByTags.test.js
+++ b/test/getWafRulesByTags.test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const nock = require('nock');
+const expect = require('expect');
+const config = require('../src/config');
+const fastlyPromises = require('../src/index');
+const response = require('./response/getWafRulesByTags.response');
+
+describe('#getWafRulesByTags', () => {
+  const fastly = fastlyPromises('923b6bd5266a7f932e41962755bd4254', '79CEhEeP8DKPQQGTXokV5M');
+  let res;
+
+  nock(config.mainEntryPoint)
+    .log(console.log)
+    .get('/service/79CEhEeP8DKPQQGTXokV5M/wafs/rfjn9II8V21LSeEgyMT9x/rule_statuses?filter[rule][tags][name]=language-css&page[number]=1&page[size]=200')
+    .reply(200, response.getWafRulesByTags);
+
+  before(async () => {
+    res = await fastly.getWafRulesByTags('rfjn9II8V21LSeEgyMT9x','language-css');
+  });
+
+  it('response should be a status 200', () => {
+    expect(res.status).toBe(200);
+  });
+
+  it('response body should exist', () => {
+    expect(res.data).toExist();
+  });
+
+  it('response body should be an array', () => {
+    expect(Array.isArray(res.data.data)).toBe(true);
+  });
+
+  it('response should contain WAF ID rfjn9II8V21LSeEgyMT9x-2077876', () => {
+    expect(res.data.data[0].id).toBe("rfjn9II8V21LSeEgyMT9x-2077876");
+  });
+
+  it('response body should contain properties', () => {
+    expect(res.data).toIncludeKeys(['links', 'meta']);
+  });
+
+});

--- a/test/response/getWafRulesByTags.response.js
+++ b/test/response/getWafRulesByTags.response.js
@@ -1,0 +1,23 @@
+'use strict';
+module.exports.getWafRulesByTags =
+{
+  "data": [
+    {
+      "id": "rfjn9II8V21LSeEgyMT9x-2077876",
+      "type": "rule_status",
+      "attributes": {
+        "status": "block"
+      }
+    }
+  ],
+  "links": {
+    "last": "http://api.fastly.com/service/79CEhEeP8DKPQQGTXokV5M/wafs/rfjn9II8V21LSeEgyMT9x/rule_statuses?filter[rule][tags][name]=language-css&page[number]=1&page[size]=100",
+    "first": "http://api.fastly.com/service/79CEhEeP8DKPQQGTXokV5M/wafs/rfjn9II8V21LSeEgyMT9x/rule_statuses?filter[rule][tags][name]=language-css&page[number]=1&page[size]=100"
+  },
+  "meta": {
+    "current_page": 1,
+    "per_page": 100,
+    "record_count": 1,
+    "total_pages": 1
+  }
+};


### PR DESCRIPTION
Was in rebase-merge hell. 
 Added a new endpoint to get rules given 
1. A WAF ID
2. A tag
3. Page number. 
As decided , we will do the pagination logic on the client side application.

Did some clean up as well. 